### PR TITLE
Use better qualified name for cpython extension module shared library

### DIFF
--- a/hatch_cpp/tests/test_project_cmake/CMakeLists.txt
+++ b/hatch_cpp/tests/test_project_cmake/CMakeLists.txt
@@ -71,19 +71,11 @@ endif()
 
 
 find_package(Python ${CSP_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter Development.Module)
-link_directories(${Python_LIBRARY_DIRS})
-include_directories(${Python_INCLUDE_DIRS})
-
-set(CMAKE_SHARED_LIBRARY_PREFIX "")
-if(NOT WIN32)
-    set(CMAKE_SHARED_LIBRARY_SUFFIX .so)
-else()
-    set(CMAKE_SHARED_LIBRARY_SUFFIX .pyd)
-endif()
 
 include_directories("${CMAKE_SOURCE_DIR}/cpp")
 
-add_library(extension SHARED cpp/project/basic.cpp)
+python_add_library(extension MODULE WITH_SOABI cpp/project/basic.cpp)
+
 set_target_properties(extension PROPERTIES PUBLIC_HEADER cpp/project/basic.hpp)
 install(TARGETS extension
         PUBLIC_HEADER DESTINATION project/include/project

--- a/hatch_cpp/tests/test_project_cmake_vcpkg/CMakeLists.txt
+++ b/hatch_cpp/tests/test_project_cmake_vcpkg/CMakeLists.txt
@@ -71,19 +71,11 @@ endif()
 
 
 find_package(Python ${CSP_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter Development.Module)
-link_directories(${Python_LIBRARY_DIRS})
-include_directories(${Python_INCLUDE_DIRS})
-
-set(CMAKE_SHARED_LIBRARY_PREFIX "")
-if(NOT WIN32)
-    set(CMAKE_SHARED_LIBRARY_SUFFIX .so)
-else()
-    set(CMAKE_SHARED_LIBRARY_SUFFIX .pyd)
-endif()
 
 include_directories("${CMAKE_SOURCE_DIR}/cpp")
 
-add_library(extension SHARED cpp/project/basic.cpp)
+python_add_library(extension MODULE WITH_SOABI cpp/project/basic.cpp)
+
 set_target_properties(extension PROPERTIES PUBLIC_HEADER cpp/project/basic.hpp)
 install(TARGETS extension
         PUBLIC_HEADER DESTINATION project/include/project

--- a/hatch_cpp/tests/test_projects.py
+++ b/hatch_cpp/tests/test_projects.py
@@ -1,8 +1,9 @@
-from os import listdir
+import contextlib
+from os import listdir, remove
 from pathlib import Path
-from shutil import rmtree
 from subprocess import check_call
 from sys import modules, path, platform
+from sysconfig import get_config_var
 
 import pytest
 
@@ -24,9 +25,17 @@ class TestProject:
         ],
     )
     def test_basic(self, project):
+
+        suffix_ext = get_config_var("EXT_SUFFIX")
+
         # cleanup
-        rmtree(f"hatch_cpp/tests/{project}/project/extension.so", ignore_errors=True)
-        rmtree(f"hatch_cpp/tests/{project}/project/extension.pyd", ignore_errors=True)
+        with contextlib.suppress(FileNotFoundError):
+            remove(f"hatch_cpp/tests/{project}/project/extension.so")
+        with contextlib.suppress(FileNotFoundError):
+            remove(f"hatch_cpp/tests/{project}/project/extension.pyd")
+        with contextlib.suppress(FileNotFoundError):
+            remove(f"hatch_cpp/tests/{project}/project/extension{suffix_ext}")
+
         modules.pop("project", None)
         modules.pop("project.extension", None)
 
@@ -40,14 +49,14 @@ class TestProject:
         )
 
         # assert built
-
+        project_dir_content = listdir(f"hatch_cpp/tests/{project}/project")
         if project == "test_project_limited_api" and platform != "win32":
-            assert "extension.abi3.so" in listdir(f"hatch_cpp/tests/{project}/project")
+            assert "extension.abi3.so" in project_dir_content
         else:
             if platform == "win32":
-                assert "extension.pyd" in listdir(f"hatch_cpp/tests/{project}/project")
+                assert "extension.pyd" in project_dir_content or f"extension{suffix_ext}" in project_dir_content
             else:
-                assert "extension.so" in listdir(f"hatch_cpp/tests/{project}/project")
+                assert "extension.so" in project_dir_content or f"extension{suffix_ext}" in project_dir_content
 
         # import
         here = Path(__file__).parent / project

--- a/hatch_cpp/toolchains/common.py
+++ b/hatch_cpp/toolchains/common.py
@@ -101,6 +101,9 @@ class HatchCppLibrary(BaseModel, validate_assignment=True):
         return value
 
     def get_qualified_name(self, platform):
+        if self.binding == "cpython" and not self.py_limited_api:
+            suffix = get_config_var("EXT_SUFFIX")
+            return f"{self.name}{suffix}"
         if platform == "win32":
             suffix = "dll" if self.binding == "generic" else "pyd"
         elif platform == "darwin":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,8 @@ branch = false
 omit = [
     "hatch_cpp/tests/integration/",
 ]
+patch = ["subprocess"]
+
 
 [tool.coverage.report]
 exclude_also = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ addopts = [
     "--junitxml=junit.xml",
 ]
 testpaths = "hatch_cpp/tests"
+norecursedirs = "vcpkg"
 
 [tool.ruff]
 line-length = 150


### PR DESCRIPTION
Shared library for a `cpython` extension module should be suffixed by
the value of the `EXT_SUFFIX` configuration variable from the `sysconfig`
module.
    
Fixes #24.

