### PR TITLE
Fix vcpkg command paths on Windows

### DIFF
--- a/hatch_cpp/tests/test_vcpkg_ref.py
+++ b/hatch_cpp/tests/test_vcpkg_ref.py
@@ -153,6 +153,27 @@ class TestVcpkgGenerate:
         assert not any("checkout" in cmd for cmd in commands)
         assert any("git clone" in cmd for cmd in commands)
 
+    def test_generate_uses_posix_command_paths(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        self._make_vcpkg_env(tmp_path)
+
+        cfg = HatchCppVcpkgConfiguration(vcpkg_triplet="x64-linux")
+        commands = cfg.generate(None)
+
+        assert "./vcpkg/bootstrap-vcpkg.sh" in commands
+        assert "./vcpkg/vcpkg install --triplet x64-linux" in commands
+
+    def test_generate_uses_windows_command_paths(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("hatch_cpp.toolchains.vcpkg.sys_platform", "win32")
+        self._make_vcpkg_env(tmp_path)
+
+        cfg = HatchCppVcpkgConfiguration(vcpkg_triplet="x64-windows-static-md")
+        commands = cfg.generate(None)
+
+        assert r"vcpkg\bootstrap-vcpkg.bat" in commands
+        assert r"vcpkg\vcpkg.exe install --triplet x64-windows-static-md" in commands
+
     def test_generate_skips_clone_when_vcpkg_root_exists(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         self._make_vcpkg_env(tmp_path)

--- a/hatch_cpp/toolchains/vcpkg.py
+++ b/hatch_cpp/toolchains/vcpkg.py
@@ -87,6 +87,11 @@ class HatchCppVcpkgConfiguration(BaseModel):
             return self.vcpkg_root / "vcpkg.exe"
         return self.vcpkg_root / "vcpkg"
 
+    def _command_path(self, path: Path) -> str:
+        if sys_platform == "win32":
+            return str(path).replace("/", "\\")
+        return f"./{path}"
+
     def _delete_dir_command(self, path: Path) -> str:
         if sys_platform == "win32":
             return f'rmdir /s /q "{path}"'
@@ -109,7 +114,7 @@ class HatchCppVcpkgConfiguration(BaseModel):
         if ref is not None:
             commands.append(f"git -C {self.vcpkg_root} checkout {ref}")
 
-        commands.append(f"./{self._bootstrap_script_path()}")
+        commands.append(self._command_path(self._bootstrap_script_path()))
         return commands
 
     def generate(self, config):
@@ -134,11 +139,11 @@ class HatchCppVcpkgConfiguration(BaseModel):
                 else:
                     vcpkg_executable = self._vcpkg_executable_path()
                     if not vcpkg_executable.exists():
-                        commands.append(f"./{bootstrap_script}")
+                        commands.append(self._command_path(bootstrap_script))
                     elif not self._is_vcpkg_working():
                         commands.append(self._delete_dir_command(vcpkg_root))
                         commands.extend(self._clone_checkout_bootstrap_commands())
 
-            commands.append(f"./{self.vcpkg_root / 'vcpkg'} install --triplet {self.vcpkg_triplet}")
+            commands.append(f"{self._command_path(self._vcpkg_executable_path())} install --triplet {self.vcpkg_triplet}")
 
         return commands


### PR DESCRIPTION
Fix vcpkg command generation on Windows by removing the POSIX ./ prefix and invoking vcpkg.exe for package installation. POSIX command paths remain unchanged.

This unblocks vcpkg-enabled Windows builds in python-project-templates/python-template-cpp#86.

Verified with the full 77-test suite, ruff, mdformat, and codespell.