### PR TITLE
Add Linux ARM64 vcpkg support

### DIFF
--- a/hatch_cpp/tests/test_vcpkg_ref.py
+++ b/hatch_cpp/tests/test_vcpkg_ref.py
@@ -83,6 +83,10 @@ class TestVcpkgRefConfig:
         cfg = HatchCppVcpkgConfiguration(vcpkg_ref=sha)
         assert cfg.vcpkg_ref == sha
 
+    def test_linux_arm64_triplet(self):
+        cfg = HatchCppVcpkgConfiguration(vcpkg_triplet="arm64-linux")
+        assert cfg.vcpkg_triplet == "arm64-linux"
+
 
 class TestResolveVcpkgRef:
     """Tests for _resolve_vcpkg_ref priority logic."""
@@ -162,6 +166,17 @@ class TestVcpkgGenerate:
 
         assert "./vcpkg/bootstrap-vcpkg.sh" in commands
         assert "./vcpkg/vcpkg install --triplet x64-linux" in commands
+
+    def test_generate_detects_linux_arm64_triplet(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("hatch_cpp.toolchains.vcpkg.sys_platform", "linux")
+        monkeypatch.setattr("hatch_cpp.toolchains.vcpkg.platform_machine", lambda: "aarch64")
+        self._make_vcpkg_env(tmp_path)
+
+        cfg = HatchCppVcpkgConfiguration()
+        commands = cfg.generate(None)
+
+        assert "./vcpkg/vcpkg install --triplet arm64-linux" in commands
 
     def test_generate_uses_windows_command_paths(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)

--- a/hatch_cpp/toolchains/vcpkg.py
+++ b/hatch_cpp/toolchains/vcpkg.py
@@ -24,6 +24,7 @@ VcpkgTriplet = Literal[
     "x86-windows",
     "arm-neon-android",
     "arm64-android",
+    "arm64-linux",
     "arm64-osx",
     "arm64-uwp",
     "arm64-windows",
@@ -31,7 +32,7 @@ VcpkgTriplet = Literal[
 ]
 VcpkgPlatformDefaults = {
     ("linux", "x86_64"): "x64-linux",
-    # ("linux", "arm64"): "",
+    ("linux", "aarch64"): "arm64-linux",
     ("darwin", "x86_64"): "x64-osx",
     ("darwin", "arm64"): "arm64-osx",
     ("win32", "x86_64"): "x64-windows-static-md",


### PR DESCRIPTION
## Description

Recognize `platform.machine() == "aarch64"` on Linux and select vcpkg's `arm64-linux` triplet. This fixes hatch-cpp metadata generation on native Linux ARM64 runners, which previously failed before compilation because no default triplet could be determined.

Adds regression coverage for both explicit triplet validation and automatic Linux ARM64 detection.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass (`make test`)
- [x] New tests added for new functionality
- [x] Documentation updated (not applicable)
- [ ] Changelog / version bump (follow-up release required)
